### PR TITLE
Move to Python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,9 @@ results
 include
 share
 lib/python2.7
+src
 
+config/src
 config/settings.*
 !config/settings.dev
 !config/settings.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,9 @@
 language: python
 
 python:
-  - "2.7.9"
+  - "3.4"
 
-cache:
-  directories:
-    - $HOME/virtualenv/python2.7.9/
-    - $HOME/.pip_cache/
-
-before_install:
-  - export PIP_DOWNLOAD_CACHE=$HOME/.pip_cache/
+cache: pip
 
 install:
   - pip install -r config/requirements.txt
@@ -21,6 +15,6 @@ before_script:
   - export PYTHONPATH=.
 
 script:
-  - flake8 .
-  - py.test -v
+  - flake8 --exclude=src .
+  - py.test -v tests/
   - jsxhint cal/static/jsx/*

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,8 +10,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # please see the online documentation at vagrantup.com.
 
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "precise64"
-  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+  config.vm.box = "ubuntu/trusty64"
 
   # expose port 5000 for Flask
   config.vm.network :forwarded_port,  guest: 5000,    host: 5000

--- a/cal/__init__.py
+++ b/cal/__init__.py
@@ -1,5 +1,5 @@
 import datetime as dt
-from StringIO import StringIO
+from io import StringIO
 
 from celery import Celery
 

--- a/cal/engineeringevents.py
+++ b/cal/engineeringevents.py
@@ -1,11 +1,10 @@
-from urllib import parse
+from urllib import parse as urlparse
 
 from bs4 import BeautifulSoup
 import requests
 from icalendar import Calendar
 
 from cal.schema import db, User, Event
-import urlparse
 
 
 def update_engineering_events():
@@ -29,18 +28,17 @@ def update_engineering_events():
         r_event = requests.get(ical_url)
         cal = Calendar.from_ical(r_event.text)
 
-	current_event = Event.query.filter(Event.sundial_id == event_id).first()
-        if current_event is None:
-            current_event = Event(name=event_name, url=url, 
-                                  sundial_id=event_id, user_id=user.id)
+        cevent = Event.query.filter(Event.sundial_id == event_id).first()
+        if cevent is None:
+            cevent = Event(name=event_name, url=url, sundial_id=event_id,
+                           user_id=user.id)
 
         # only one event in cal
         for event in cal.walk('vevent'):
-            current_event.start = event.get('dtstart').dt.replace(tzinfo=None)
-            current_event.end = event.get('dtend').dt.replace(tzinfo=None)
-            current_event.description = event.get('description')
-            current_event.location = event.get('location')
+            cevent.start = event.get('dtstart').dt.replace(tzinfo=None)
+            cevent.end = event.get('dtend').dt.replace(tzinfo=None)
+            cevent.description = event.get('description')
+            cevent.location = event.get('location')
 
-
-        db.session.add(current_event)
+        db.session.add(cevent)
     db.session.commit()

--- a/cal/engineeringevents.py
+++ b/cal/engineeringevents.py
@@ -1,13 +1,14 @@
-from __future__ import absolute_import
+from urllib import parse
+
+from bs4 import BeautifulSoup
+import requests
+from icalendar import Calendar
+
+from cal.schema import db, User, Event
+import urlparse
 
 
 def update_engineering_events():
-    from cal.schema import db, User, Event
-    from bs4 import BeautifulSoup
-    import requests
-    from icalendar import Calendar
-    import urlparse
-
     r = requests.get('http://engineering.columbia.edu/feeds/events')
     soup = BeautifulSoup(r.text)
 
@@ -18,7 +19,6 @@ def update_engineering_events():
 
         event_name = current_soup.find('title').text
         url = current_soup.find('link').get_text()
-        # event url
         u = urlparse.urlparse(url)
         event_id = urlparse.parse_qs(u.query)["id"][0]
 

--- a/cal/fb.py
+++ b/cal/fb.py
@@ -46,40 +46,6 @@ def get_users():
 
 
 def update_fb_events():
-<<<<<<< HEAD
-    for user in User.query.all():
-        if user.fb_id is None:
-            continue
-
-        events = graph.get_connections(id=user.fb_id, connection_name="events")
-        events = events["data"]
-        for event in events:
-            event = graph.get_object(id=event["id"])
-            event_id = int(event['id'])
-
-            current_event = Event.query.filter_by(fb_id=event_id).first()
-            if current_event is None:   # create new event
-                current_app.logger.debug("New fb event from {}: {}"
-                                         .format(user.fb_id, event['id']))
-                current_event = Event(fb_id=event_id)
-
-            # Parse the start and end times.
-            start = iso8601.parse_date(event["start_time"])
-            current_event.start = start.replace(tzinfo=None)
-            end = event.get('end_time', None)
-            if end is not None:
-                end = iso8601.parse_date(end)
-                current_event.end = end.replace(tzinfo=None)
-
-            # Update other fields.
-            current_event.user_id = user.id
-            current_event.description = event.get("description", None)
-            current_event.location = event.get('location', None)
-            current_event.name = event['name']
-            current_event.url = "https://www.facebook.com/" + event['id']
-
-            db.session.add(current_event)
-=======
     url = "https://graph.facebook.com/v2.3/"
     payload = {"access_token": FACEBOOK_ACCESS_TOKEN}
 

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -10,7 +10,6 @@ from os import environ, pardir
 from os.path import join, abspath, dirname
 from sys import exit
 
-
 try:
     # flask settings
     HOST = environ['HOST']
@@ -31,8 +30,6 @@ try:
 
 except KeyError as e:
     """ Throw an error if a setting is missing """
-    print "ERR MSG: {}".format(e.message)
-    print ("Some of your settings aren't in the environment."
-           "You probably need to run:"
-           "\n\n\tsource config/<your settings file>")
-    exit(1)
+    exit("Some of your settings aren't in the environment."
+         "You probably need to run:"
+         "\n\tsource config/<your settings file>\n")

--- a/config/bootstrap.sh
+++ b/config/bootstrap.sh
@@ -15,10 +15,13 @@ install sqlite3
 
 # install python
 install python3
-install python3-pip
 install python3-dev
 install python3-software-properties
 install git
+
+wget https://raw.github.com/pypa/pip/master/contrib/get-pip.py
+sudo python3 get-pip.py
+rm get-pip.py
 
 sudo pip3 install -r /vagrant/config/requirements.txt
 

--- a/config/bootstrap.sh
+++ b/config/bootstrap.sh
@@ -14,12 +14,13 @@ apt-get update
 install sqlite3
 
 # install python
-install python
-install python-pip
-install python-dev
-install python-software-properties
+install python3
+install python3-pip
+install python3-dev
+install python3-software-properties
+install git
 
-sudo pip install -r /vagrant/config/requirements.txt
+sudo pip3 install -r /vagrant/config/requirements.txt
 
 
 exit 0

--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -1,13 +1,14 @@
 Flask==0.10.1
 Flask-SQLAlchemy==2.0
 Flask-Testing==0.4.2
--e git+git@github.com:tonet666p/Flask-WhooshAlchemy.git@python-3-compatibility#egg=flask_whooshalchemy_py3
+-e git+https://github.com/tonet666p/Flask-WhooshAlchemy.git@python-3-compatibility#egg=flask_whooshalchemy_py3
 Jinja2==2.7.3
 MarkupSafe==0.23
 SQLAlchemy==1.0.1
 Werkzeug==0.10.4
 PyYAML==3.11
 iso8601==0.1.10
+requests==2.6.0
 itsdangerous==0.24
 pytz==2015.2
 icalendar==3.9.0

--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -1,13 +1,12 @@
 Flask==0.10.1
 Flask-SQLAlchemy==2.0
-Flask-WhooshAlchemy==0.56
 Flask-Testing==0.4.2
+-e git+git@github.com:tonet666p/Flask-WhooshAlchemy.git@python-3-compatibility#egg=flask_whooshalchemy_py3
 Jinja2==2.7.3
 MarkupSafe==0.23
 SQLAlchemy==1.0.1
 Werkzeug==0.10.4
 PyYAML==3.11
-facebook-sdk==0.4.0
 iso8601==0.1.10
 itsdangerous==0.24
 pytz==2015.2

--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -8,10 +8,11 @@ SQLAlchemy==1.0.1
 Werkzeug==0.10.4
 PyYAML==3.11
 iso8601==0.1.10
-requests==2.6.0
+requests==2.6.2
 itsdangerous==0.24
 pytz==2015.2
 icalendar==3.9.0
 celery==3.1.18
 fuzzywuzzy==0.5.0
 python-Levenshtein==0.12.0
+beautifulsoup4==4.3.2

--- a/create.py
+++ b/create.py
@@ -7,7 +7,7 @@ with app.app_context():
     # Populate the user database
     with open('cal/groups.yml') as fin:
         users = yaml.load(fin)
-    for username, ids in users.iteritems():
+    for username, ids in users.items():
         if User.query.filter_by(name=username).first() is None:
             new_user = User(name=username)
             new_user.fb_id = ids.get('fb', None)

--- a/external/utils.py
+++ b/external/utils.py
@@ -1,0 +1,15 @@
+import itertools
+from enum import Enum
+
+
+class Constant(Enum):   # constant that is not equal to anything else
+    null = 1
+
+
+def grouper(iterable, n=50):
+    "Collect data into fixed-length chunks or blocks"
+    args = [iter(iterable)] * n
+    chunks = itertools.zip_longest(fillvalue=Constant.null, *args)
+
+    return ((item for item in chunk if item is not Constant.null)
+            for chunk in chunks)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,10 +1,10 @@
 import json
-from urllib import urlencode
+from urllib.parse import urlencode
 
 
 def assert_json_equal(response, query):
     assert response.status_code == 200
-    rdata = json.loads(response.data)
+    rdata = json.loads(response.data.decode())
     data = [d.to_json() for d in query.all()]
 
     # "data" is only key in rdata


### PR DESCRIPTION
So far, we've been lucky that Facebook handles all kinds of unicode things for us. Unfortunately, CUIT doesn't (so [web scraping](https://calendar.columbia.edu/sundial/webapi/get.php?vt=detail&id=78066&con=standalone&br=seas_events) can be a pain).

If we have to deal with text encoding issues, I'd much rather move to Python 3. Unicode in Python 2's a nightmare. Besides, Python 3 gives us [all](https://www.python.org/dev/peps/pep-3107/) [kinds](http://mypy-lang.org/) [of](http://asmeurer.github.io/python3-presentation/python3-presentation.pdf) [goodies](http://compiletoi.net/fast-scraping-in-python-with-asyncio.html) we can start playing with.

Anyways, the actual port is fairly straightforward:
- Trivial syntax changes (e.g. `print()` instead of `print`)
- A bit more care with using `decode` and `encode`
- Rip out `facebook-sdk` and write a scraper w/ `requests` (this is actually necessary anyways: `facebook-sdk` still uses the v1.0 API, which will be deprecated on April 30th. Considering it's been two years since a release of `facebook-sdk`, I'm not hopeful about our prospects). This lets us use facebook's bulk-querying apis, which is nice.
- Use a [branch](https://github.com/tonet666p/Flask-WhooshAlchemy/tree/python-3-compatibility) of `flask-whooshalchemy` that's python 3 compatible. There's a PR to merge into upstream, but I doubt that'll happen

Note: to avoid unicode errors, you have to `rm -rf whoosh_alchemy`, `rm events.db`, and run `python create.py` again to rebuild the whoosh indexes.

~~This depends on #80 (to preempt merge conflicts).~~ Naturally, I'd like to merge soon to avoid huge tangles of merge conflicts later.
