### PR TITLE
js/webpack-source-map

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -69,7 +69,7 @@ module.exports = {
   },
 
   debug: true,
-  devtool: 'eval-cheap-module-source-map',
+  devtool: 'source-map',
   devServer: {
     contentBase: './cal/dist',
     historyApiFallback: true


### PR DESCRIPTION
Enable proper SourceMapping for browser debugging.
